### PR TITLE
[FIX] Code injection through "eval()"

### DIFF
--- a/src/messenger-node.js
+++ b/src/messenger-node.js
@@ -10,6 +10,8 @@ const CLI_ICON_PASS = '✓';
 const CLI_ICON_WARN = '♺ ';
 const CLI_ICON_NOTE = '✏︎ ';
 
+const VALID_COLOR = /^[a-zA-Z]+$/;
+
 const messenger = {
   version: () => {
     return pkgInfo.version;
@@ -68,7 +70,10 @@ const messenger = {
   line: color => {
     if (color.length > 0) {
       try {
-        eval(`cl.${color}()`); // eslint-disable-line
+        if(VALID_COLOR.test(color))
+          eval(`cl.${color}()`); // eslint-disable-line
+        else
+          console.error(chalk.bgRed,bold(`Invalid Color: ${color}`));
       }
       catch (e) {
         console.error(chalk.bgRed.bold(`Invalid Color: ${color}`));


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-cd-messenger

### ⚙️ Description *

A `code injection` issue existed in the `line` function due to the usage of `eval` on `user-supplied` inputs which could lead to `JS/command injection`.

### 💻 Technical Description *

I inserted a check for `valid` colors in order to `match` only values containing `letters`: the colors accepted by `chalkline` are the ones taken from `chalk`, which takes the names from https://github.com/Marak/colors.js (see `README.md`  --> `colors and styles!`)

### 🐛 Proof of Concept (PoC) *

1. Download the package
2. Make the PoC file:

```javascript
// poc.js
var a = require("./cd-messenger");
a.line("red(); console.log('JHU'); //");
```
3. A `red` line and the `JHU` string will be printed 

![Screenshot from 2020-08-06 11-55-23](https://user-images.githubusercontent.com/33063403/89520713-92926280-d7de-11ea-8b5e-a90001ab60ac.png)


### 🔥 Proof of Fix (PoF) *

Same steps of above, but an error is displayed and no `evaluation` happens

![Screenshot from 2020-08-06 12-09-12](https://user-images.githubusercontent.com/33063403/89520742-a0e07e80-d7de-11ea-8d13-df54722f583f.png)


### 👍 User Acceptance Testing (UAT)

The `fix` checks only if the color passed is composed by only `letters`, making impossible break anything :smile: