### PR TITLE
Fix code injection

### DIFF
--- a/src/messenger-node.js
+++ b/src/messenger-node.js
@@ -67,10 +67,10 @@ const messenger = {
   },
   line: color => {
     if (color.length > 0) {
-      try {
-        eval(`cl.${color}()`); // eslint-disable-line
+      if (typeof cl[color] === 'function') {
+        cl[color]();
       }
-      catch (e) {
+      else {
         console.error(chalk.bgRed.bold(`Invalid Color: ${color}`));
       }
     }


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-cd-messenger

### ⚙️ Description *

Instead of evaluating user-controlled variables, which leads to code injection, we check if the color exists within the chalkline module, and if it is, we invoke it. 

### 💻 Technical Description *

I have replaced the call to eval() in messenger-node.js with a simple check if the selected color exists, and if it does, invoke the function defined by the chalkline module.  

### 🐛 Proof of Concept (PoC) *
When you run the following code in a directory with the `cd-messenger` module installed, a file named `injected.txt` should show up in your current working directory:
```js
const cd = require('cd-messenger');
cd.line('red(); require("fs").writeFileSync("injected.txt", "injected")//');
```

### 🔥 Proof of Fix (PoF) *

When the above code is ran on my fork of the module, it throws an error (as shown below) and no file is created:

`Invalid Color: red(); require("fs").writeFileSync("injected.txt", "")//`

### 👍 User Acceptance Testing (UAT)

I have run the tests using `npm test`, and they have all passed successfully:
```
  Given an instance of my messenger
    when I need the name
      ✓ should return the name
    when I need the version
      ✓ should return the version

  ==> Messenger Node (Console)
    ✓ should be instance of messenger-node
    ✓ should contain log method
    ✓ should contain all methods
test message
    ✓ should return supplied message
    ✓ should return stub value
test call 1
    ✓ should stub log method
    ✓ should be a spy


  9 passing (49ms)
```

